### PR TITLE
Adding maven enforcer plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,19 @@
   </modules>
 
   <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.3.1</version>
+        <configuration>
+          <rules>
+            <DependencyConvergence />
+          </rules>
+          <fail>true</fail>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 
   <reporting>


### PR DESCRIPTION
This commit add the maven enforcer plugin to test whether all dependency libraries converge to the same version. It is not included in the normal build cycle it must be run explicitly with "mvn enforcer:enforce". (Write access to the repo for me has not yet been configured)
